### PR TITLE
fixed broken ios files

### DIFF
--- a/src/ios/Screenshot.m
+++ b/src/ios/Screenshot.m
@@ -53,8 +53,8 @@
 
 	[webView.layer renderInContext:ctx];
 
-	UIImage image = UIGraphicsGetImageFromCurrentImageContext();
-	NSData imageData = UIImageJPEGRepresentation(image,[quality floatValue]);
+	UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+	NSData *imageData = UIImageJPEGRepresentation(image,[quality floatValue]);
 	[imageData writeToFile:jpgPath atomically:NO];
 
 	UIGraphicsEndImageContext();

--- a/www/Screenshot.js
+++ b/www/Screenshot.js
@@ -18,6 +18,6 @@ module.exports = {
 			callback && callback(null,res);
 		}, function(error){
 			callback && callback(error);
-		}, "Screenshot", "saveScreenshot", [format,quality, filename]);
+		}, "Screenshot", "saveScreenshot", [format, quality, filename]);
 	}
 };


### PR DESCRIPTION
Fixed missing  '-'  in the most recent screenshot.m file.  Tough to see this change on github because it shows the deleted line with the minus sign to show its removal .  Without the dash, the code will not build and throws "expected identifier or '(' ".

Also added a 3rd argument in the .js file to match the new .m file.  Otherwise there is an index out of range error ( specifically "webView:decidePolicyForNavigationAction:request:frame:decisionListener: delegate: <NSRangeException> -[__NSCFArray objectAtIndex:]: index (2) beyond bounds (2)") caused by referencing an argument that doesn't exist.

Also added '*' in front of a couple of variable declarations.  Without them I got an error during build saying "Semanitic issue Interface type cannot be statically allocated".
