### PR TITLE
bump version and add Crosswalk mention to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ cordova plugin add https://github.com/gitawego/cordova-screenshot.git
 
 notice:
 in iOS, only jpg format is supported
+in Android, the default WebView and [Crosswalk](https://crosswalk-project.org/documentation/cordova.html) are both supported
 
 ##usage
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<plugin id="com.darktalker.cordova.screenshot" version="0.1.0" 
+<plugin id="com.darktalker.cordova.screenshot" version="0.1.1" 
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android" >
     <name>Screenshot</name>


### PR DESCRIPTION
As the comment says, I bumped the version and added a note mentioning Crosswalk support to the documentation.  If you don't want the documentation to mention Crosswalk, please just bump the version number.  That way we can document the version that supports Crosswalk.  Thanks!