### PR TITLE
Screenshot of all views, not only webview

### DIFF
--- a/src/android/Screenshot.java
+++ b/src/android/Screenshot.java
@@ -75,7 +75,7 @@ public class Screenshot extends CordovaPlugin {
 			}
 		} else {
 
-			View view = cordova.getActivity().getWindow().getDecorView().getRootView();
+			View view = webView.getView().getRootView();
 			view.setDrawingCacheEnabled(true);
 			bitmap = Bitmap.createBitmap(view.getDrawingCache());
 			view.setDrawingCacheEnabled(false);

--- a/src/ios/Screenshot.m
+++ b/src/ios/Screenshot.m
@@ -48,14 +48,9 @@
 
 	CGContextRef ctx = UIGraphicsGetCurrentContext();
 	[[UIColor blackColor] set];
-	CGContextTranslateCTM(ctx, 0, 0);
 	CGContextFillRect(ctx, imageRect);
-
-    if ([webView respondsToSelector:@selector(drawViewHierarchyInRect:afterScreenUpdates:)]) {
-        [webView drawViewHierarchyInRect:webView.bounds afterScreenUpdates:YES];
-    } else {
-        [webView.layer renderInContext:ctx];
-    }
+  UIWindow *window = [UIApplication sharedApplication].keyWindow;
+  [window.layer renderInContext:ctx];
 
 	UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
 	NSData *imageData = UIImageJPEGRepresentation(image,[quality floatValue]);


### PR DESCRIPTION
I need to make a screenshot in apps with a mix of native components and currently the plugin only take screenshot of cordova webview.

With this PR the screenshot is from the top most view/window including child native components.

I'm sorry but i didn't test it with crosswalk.