### PR TITLE
Bug fixing (orientation and problem with distorted html-img)

### DIFF
--- a/src/ios/Screenshot.m
+++ b/src/ios/Screenshot.m
@@ -29,16 +29,7 @@
 	CGRect imageRect;
 	CGRect screenRect = [[UIScreen mainScreen] bounds];
 
-	// statusBarOrientation is more reliable than UIDevice.orientation
-	UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
-
-	if (orientation == UIInterfaceOrientationLandscapeLeft || orientation == UIInterfaceOrientationLandscapeRight) {
-		// landscape check
-		imageRect = CGRectMake(0, 0, CGRectGetHeight(screenRect), CGRectGetWidth(screenRect));
-	} else {
-		// portrait check
-		imageRect = CGRectMake(0, 0, CGRectGetWidth(screenRect), CGRectGetHeight(screenRect));
-	}
+	imageRect = CGRectMake(0, 0, CGRectGetWidth(screenRect), CGRectGetHeight(screenRect));
 
 	// Adds support for Retina Display. Code reverts back to original if iOs 4 not detected.
 	if (NULL != UIGraphicsBeginImageContextWithOptions)

--- a/src/ios/Screenshot.m
+++ b/src/ios/Screenshot.m
@@ -20,9 +20,8 @@
 {
 	UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
 	CGRect rect = [keyWindow bounds];
-	UIGraphicsBeginImageContext(rect.size);
-	CGContextRef ctx = UIGraphicsGetCurrentContext();
-	[keyWindow.layer renderInContext:ctx];   
+	UIGraphicsBeginImageContextWithOptions(rect.size, YES, 0);
+	[keyWindow drawViewHierarchyInRect:keyWindow.bounds afterScreenUpdates:YES];
 	UIImage *img = UIGraphicsGetImageFromCurrentImageContext();
 	UIGraphicsEndImageContext();
 	return img;


### PR DESCRIPTION
Using the plugin with an iPad 2 (iOS 8.1) and with an iPad mini 3 (iOS 8.4), the screenshot result was always in portrait.
Playing with the code (I'm not a Objective-C programmer) I noticed that "screenRect" dimensions changed with changing of orientation:
NSLog(@"%@", NSStringFromCGRect(screenRect));
Landscape => {{0, 0}, {1024, 768}}
Portrait => {{0, 0}, {768, 1024}}
So I removed the checking of orientation and now it works. I noticed that also another guy had this problem, maybe this behavior changed with iOS 8?