### PR TITLE
Scaledown option on Screenshot.URI()

### DIFF
--- a/www/Screenshot.js
+++ b/www/Screenshot.js
@@ -22,13 +22,14 @@ module.exports = {
 		}, "Screenshot", "saveScreenshot", [format, quality, filename]);
 	},
 
-	URI:function(callback, quality){
+	URI:function(callback, quality, scaleDown){
 		quality = typeof(quality) !== 'number'?100:quality;
+		scaleDown = typeof(scaleDown) !== 'number'?1:scaleDown;
 		exec(function(res){
 			callback && callback(null, res);
 		}, function(error){
 			callback && callback(error);
-		}, "Screenshot", "getScreenshotAsURI", [quality]);
+		}, "Screenshot", "getScreenshotAsURI", [quality, scaleDown]);
 
 	}
 };


### PR DESCRIPTION
Add a "scaleDown" option to Screenshot.URI().
If scaleDown is set to a value > 1, the resulting image will be scaled down by that amount.

I changed a bit the way the base64 encoding is generated (improves performance).
