### PR TITLE
Compatibility with older Cordova-Android versions

### DIFF
--- a/src/android/Screenshot.java
+++ b/src/android/Screenshot.java
@@ -217,7 +217,6 @@ public class Screenshot extends CordovaPlugin {
         return false;
     }
 
-    @Override
     public void onRequestPermissionResult(int requestCode, String[] permissions,
                                           int[] grantResults) throws JSONException
     {


### PR DESCRIPTION
Don't `@Override` `onRequestPermissionResult` because that's why `PermissionHelper.java` was added in the first place: the superclass may not have this method (older Cordova-Android versions). The `PermissionHelper` fixes that with reflection.