### PR TITLE
Fix iOS animation flush problems

### DIFF
--- a/src/ios/Screenshot.m
+++ b/src/ios/Screenshot.m
@@ -21,7 +21,7 @@
 	UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
 	CGRect rect = [keyWindow bounds];
 	UIGraphicsBeginImageContextWithOptions(rect.size, YES, 0);
-	[keyWindow drawViewHierarchyInRect:keyWindow.bounds afterScreenUpdates:YES];
+	[keyWindow drawViewHierarchyInRect:keyWindow.bounds afterScreenUpdates:NO];
 	UIImage *img = UIGraphicsGetImageFromCurrentImageContext();
 	UIGraphicsEndImageContext();
 	return img;


### PR DESCRIPTION
Proposed solution for the https://github.com/gitawego/cordova-screenshot/issues/52 issue.

Looks like this is a known problem:
http://stackoverflow.com/questions/23157653/drawviewhierarchyinrectafterscreenupdates-delays-other-animations
But suggested Apple solution takes more than 100ms, while current solution takes ~80-70ms. (Tested at iPhone 6 Plus).
Thanks @theskull31 

@gitawego what do you think? Any known side effects about solution in this PR?

Thanks.