### PR TITLE
Synchronous version of getScreenshotAsURI function

### DIFF
--- a/src/ios/Screenshot.m
+++ b/src/ios/Screenshot.m
@@ -16,6 +16,12 @@
 
 @synthesize webView;
 
+CGFloat statusBarHeight()
+{
+    CGSize statusBarSize = [[UIApplication sharedApplication] statusBarFrame].size;
+    return MIN(statusBarSize.width, statusBarSize.height);
+}
+
 - (UIImage *)getScreenshot
 {
 	UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
@@ -24,7 +30,20 @@
 	[keyWindow drawViewHierarchyInRect:keyWindow.bounds afterScreenUpdates:NO];
 	UIImage *img = UIGraphicsGetImageFromCurrentImageContext();
 	UIGraphicsEndImageContext();
-	return img;
+
+	// cut the status bar from the screenshot
+	CGRect smallRect = CGRectMake (0,statusBarHeight()*img.scale,rect.size.width*img.scale,rect.size.height*img.scale);
+ 
+	CGImageRef subImageRef = CGImageCreateWithImageInRect(img.CGImage, smallRect);
+	CGRect smallBounds = CGRectMake(0,0,CGImageGetWidth(subImageRef), CGImageGetHeight(subImageRef));
+
+	UIGraphicsBeginImageContext(smallBounds.size);
+	CGContextRef context = UIGraphicsGetCurrentContext();
+	CGContextDrawImage(context,smallBounds,subImageRef);
+	UIImage* cropped = [UIImage imageWithCGImage:subImageRef];
+	UIGraphicsEndImageContext();  
+
+	return cropped;
 }
 
 - (void)saveScreenshot:(CDVInvokedUrlCommand*)command

--- a/www/Screenshot.js
+++ b/www/Screenshot.js
@@ -30,5 +30,15 @@ module.exports = {
 			callback && callback(error);
 		}, "Screenshot", "getScreenshotAsURI", [quality]);
 
+	},
+
+	URISync:function(callback,quality){
+		var method = navigator.userAgent.indexOf("Android") > -1 ? "getScreenshotAsURISync" : "getScreenshotAsURI";
+		quality = typeof(quality) !== 'number'?100:quality;
+		exec(function(res){
+			callback && callback(null,res);
+		}, function(error){
+			callback && callback(error);
+		}, "Screenshot", method, [quality]);
 	}
 };


### PR DESCRIPTION
I add the synchronous version of `getScreenshotAsURI` function in Android. 

The situation is that I want to use the plugin to realize page transition animation in my application. To do this, I take a screenshot before leaving the current page and stock the uri of the screenshot in a variable for future use. The problem is that for some reason, I can't pass the page change code as a callback function for `navigator.screenshot.URI`. So sometimes the page has already changed before the screenshot is taken. In order to overcome this problem, I add a synchronous version of `getScreenshotAsURI`.